### PR TITLE
:hammer: Update tag name from aerabi to gitweekly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE?=aerabi/git-weekly
+IMAGE?=gitweekly/git-weekly
 TAG?=latest
 
 BUILDER=buildx-multi-arch

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The first iteration of this extension lists available issue of Git Weekly.
 ## Install
 
 ```shell
-docker extension install aerabi/git-weekly:latest
+docker extension install gitweekly/git-weekly:latest
 ```
 
 There are separate builds available for ARM or AMD architectures.
@@ -15,19 +15,19 @@ There are separate builds available for ARM or AMD architectures.
 For ARM:
 
 ```shell
-docker extension install aerabi/git-weekly:v1-arm64
+docker extension install gitweekly/git-weekly:v1-arm64
 ```
 
 For AMD:
 
 ```shell
-docker extension install aerabi/git-weekly:v1-amd64
+docker extension install gitweekly/git-weekly:v1-amd64
 ```
 
 ## Build
 
-To build the Docker image for the Docker Desktop extension:
+To build the extension and push for both ARM and AMD architectures, do:
 
 ```shell
-docker build -t aerabi/git-weekly:latest .
+bash install-and-push.sh
 ```

--- a/install-and-push.sh
+++ b/install-and-push.sh
@@ -1,9 +1,9 @@
-docker build --platform=linux/amd64 -t aerabi/git-weekly:v1-amd64 .
-docker build --platform=linux/arm64 -t aerabi/git-weekly:v1-arm64 .
-docker build --platform=linux/amd64 -t aerabi/git-weekly:v1 .
-docker build --platform=linux/amd64 -t aerabi/git-weekly:latest .
+docker build --platform=linux/amd64 -t gitweekly/git-weekly:v1-amd64 .
+docker build --platform=linux/arm64 -t gitweekly/git-weekly:v1-arm64 .
+docker build --platform=linux/amd64,linux/arm64 -t gitweekly/git-weekly:v1 .
+docker build --platform=linux/amd64,linux/arm64 -t gitweekly/git-weekly:latest .
 
-docker push aerabi/git-weekly:v1-amd64
-docker push aerabi/git-weekly:v1-arm64
-docker push aerabi/git-weekly:v1
-docker push aerabi/git-weekly:latest
+docker push gitweekly/git-weekly:v1-amd64
+docker push gitweekly/git-weekly:v1-arm64
+docker push gitweekly/git-weekly:v1
+docker push gitweekly/git-weekly:latest


### PR DESCRIPTION
The Docker org gitweekly is sponsored by Docker and enables Scout.